### PR TITLE
Fix missing variable declaration

### DIFF
--- a/aspJSON1.19.asp
+++ b/aspJSON1.19.asp
@@ -260,6 +260,7 @@ Class aspJSON
 	End Function
 
 	Private Function aj_ReadNumericValue(ByVal val)
+		Dim numdecimals
 		If Instr(val, ".") > 0 Then
 			numdecimals = Len(val) - Instr(val, ".")
 			val = Clng(Replace(val, ".", ""))


### PR DESCRIPTION
Declaration required when an ASP page has `Option Explicit`.