### PR TITLE
Fix double backslash parsing

### DIFF
--- a/aspJSON1.19.asp
+++ b/aspJSON1.19.asp
@@ -227,14 +227,15 @@ Class aspJSON
 	End Function
 
 	Private Function aj_JSONDecode(ByVal val)
+		val = Replace(val, "\\", "$DEFER$DOUBLE_BACKSLASH$")
 		val = Replace(val, "\""", """")
-		val = Replace(val, "\\", "\")
 		val = Replace(val, "\/", "/")
 		val = Replace(val, "\b", Chr(8))
 		val = Replace(val, "\f", Chr(12))
 		val = Replace(val, "\n", Chr(10))
 		val = Replace(val, "\r", Chr(13))
 		val = Replace(val, "\t", Chr(9))
+		val = Replace(val, "$DEFER$DOUBLE_BACKSLASH$", "\")
 		aj_JSONDecode = Trim(val)
 	End Function
 


### PR DESCRIPTION
Strings with a double backslash should be interpreted as
a single backslash followed by the next character verbatim.

Examples:
- `\\n` → `\n`
- `\\r` → `\r`
- `\\t` → `\t`